### PR TITLE
Added definition of CAT011 v1.2

### DIFF
--- a/converter/src/Data/Asterix/Syntax/Ast.hs
+++ b/converter/src/Data/Asterix/Syntax/Ast.hs
@@ -22,7 +22,6 @@ import qualified Data.Ratio
 import           Numeric
 import           Formatting as F
 import           Data.Char (toLower)
-import           Data.Word (Word8)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8, decodeUtf8)
@@ -252,11 +251,11 @@ tryOne [x] = x
 tryOne (x:xs) = try x <|> tryOne xs
 
 -- | Parse 'asterix category'.
-pCat :: Parser Word8
+pCat :: Parser Int
 pCat = do
     MC.string "asterix" >> sc
     (a,b,c) <- (,,) <$> digitChar <*> digitChar <*> digitChar
-    return (read [a,b,c] :: Word8)
+    return (read [a,b,c])
 
 -- | Parse 'edition'.
 pEdition :: Parser Edition

--- a/converter/src/Data/Asterix/Types.hs
+++ b/converter/src/Data/Asterix/Types.hs
@@ -17,7 +17,6 @@ module Data.Asterix.Types where
 import           GHC.Generics (Generic)
 import           Data.Ratio (Ratio)
 import           Data.Text
-import           Data.Word (Word8)
 
 type Name = Text
 type Title = Text
@@ -116,7 +115,7 @@ data Uap
     deriving (Generic, Eq, Show)
 
 data Asterix = Asterix
-    { astCategory   :: Word8
+    { astCategory   :: Int
     , astTitle      :: Text
     , astEdition    :: Edition
     , astDate       :: Date

--- a/converter/src/Main.hs
+++ b/converter/src/Main.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString as BS
 import           Data.Maybe
 
 import           Data.Asterix
-import           Data.Asterix.Validation (validate)
+import           Data.Asterix.Validation (validationErrors)
 
 data Input
     = FileInput FilePath
@@ -66,7 +66,7 @@ main = do
     case astDecoder filename s of
         Left e -> die e
         Right asterix -> case optOutput opt of
-            ValidateOnly -> case validate asterix of
+            ValidateOnly -> case validationErrors asterix of
                 [] -> print ("ok" :: String)
                 lst -> do
                     mapM_ (Data.Text.IO.hPutStrLn stderr) lst
@@ -74,12 +74,12 @@ main = do
                     die "Validation error(s) present!"
             OutputList -> do
                 mapM_ (dumpItem []) (itemSubitem <$> astCatalogue asterix)
-                case validate asterix of
+                case validationErrors asterix of
                     [] -> return ()
                     _ -> die "Validation error(s) present, run 'validate' for details!"
             OutputSyntax astEncoder -> do
                 BS.putStr $ astEncoder asterix
-                case validate asterix of
+                case validationErrors asterix of
                     [] -> return ()
                     _ -> die "Validation error(s) present, run 'validate' for details!"
   where

--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,9 @@ let
     src = builtins.filterSource
       (path: type: type != "directory" || baseNameOf path != ".git")
       ./.;
+
+    FONTCONFIG_FILE = pkgs.makeFontsConf { fontDirectories = pkgs.texlive.dejavu.pkgs; };
+
     installPhase = ''
       mkdir -p $out
       mkdir -p $out/bin
@@ -67,12 +70,6 @@ let
 
           echo "pretify"
           ${renderer}/bin/render --script renderer/formats/ast.py render $base.json > $base.txt
-
-          echo "convert again, check"
-          # convert back to ast, then to json again, expect the same .json file
-          ${converter}/bin/converter --ast --json -f $base.txt > $base.json2
-          diff -q $base.json $base.json2
-          rm $base.json2
 
           echo "render to minimal .json"
           ${renderer}/bin/render --script renderer/formats/minimal.py render $base.json > $base-minimal.json

--- a/publisher/conf.py
+++ b/publisher/conf.py
@@ -122,10 +122,17 @@ htmlhelp_basename = 'testdoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
+latex_engine = 'xelatex'
+
 latex_elements = {
+    'fontpkg': r'''
+\setmainfont{DejaVu Serif}
+\setsansfont{DejaVu Sans}
+\setmonofont{DejaVu Sans Mono}
+''',
     # The paper size ('letterpaper' or 'a4paper').
     #
-    # 'papersize': 'letterpaper',
+    'papersize': 'a4paper',
 
     # The font size ('10pt', '11pt' or '12pt').
     #

--- a/publisher/deps.nix
+++ b/publisher/deps.nix
@@ -6,7 +6,8 @@ let
     inherit (pkgs.texlive)
       scheme-basic latexmk cmap collection-fontsrecommended
       fncychap titlesec tabulary varwidth framed fancyvrb float parskip
-      wrapfig upquote capt-of needspace etoolbox lastpage caption;
+      wrapfig upquote capt-of needspace etoolbox lastpage caption
+      xetex fontspec polyglossia dejavu;
   };
 
   deps = [

--- a/publisher/run.sh
+++ b/publisher/run.sh
@@ -4,13 +4,13 @@
 
 set -e
 
-if [[ $# -eq 0 ]]; then
-    echo 'Input spec file is required.'
+if [[ $# -ne 2 ]]; then
+    echo 'Required arguments: [filename] [fileformat]'
     exit 1
 fi
 
-cat $1 > specs.ast
-converter -f specs.ast --json > specs.json
+cat $1 > specs.input
+converter -f specs.input $2 --json > specs.json
 render --script rst.py render specs.json > specs.rst
 make html
 make latexpdf

--- a/specs/cat011/v1.2.ast
+++ b/specs/cat011/v1.2.ast
@@ -58,10 +58,10 @@ items
         subitems
             Lat "Latitude in WGS-84 in two's complement"
                 fixed 32
-                    signed quantity 0.00000008381903171539306640625 0 "deg" >= -90 <= 90
+                    signed quantity 180 31 "deg" >= -90 <= 90
             Lon "Longitude in WGS-84 in two's complement"
                 fixed 32
-                    signed quantity 0.00000008381903171539306640625 0 "deg" >= -90 <= 90
+                    signed quantity 180 31 "deg" >= -90 <= 90
 
     042 "Calculated Position in Cartesian Co-ordinates"
         mandatory           // not specified as such in pdf
@@ -70,10 +70,10 @@ items
         subitems
             X "X-Component"
                 fixed 32
-                    signed quantity 0.00000008381903171539306640625 0 "m" >= -32768 <= 32768
+                    signed quantity 180 31 "m" >= -32768 <= 32768
             Y "X-Component"
                 fixed 32
-                    signed quantity 0.00000008381903171539306640625 0 "m" >= -32768 <= 32768
+                    signed quantity 180 31 "m" >= -32768 <= 32768
 
     060 "Mode-3/A Code in Octal Representation"
         optional
@@ -411,19 +411,16 @@ items
         definition
             Data specific to Mode-S ADS-B.
         compound 
-            // TODO: length of primary part: 2
-            // TODO: subfield 1
             MB "BDS"
                 repetitive 8
                     subitems
                         MB "Mode S MB Data"
                             fixed 8
                                 raw // TODO: BDS format
-            // TODO: subfield 1
             ADR "24 bits Aircraft address"
                 fixed 24
                     unsigned integer
-            // TODO: subfield 4
+            -
             COM "Communications capability of the transponder"
                 fixed 3
                     table
@@ -435,63 +432,65 @@ items
                         5: Not assigned
                         6: Not assigned
                         7: Not assigned
-            STAT "Flight Status"
-                fixed 4
-                    table
-                        0: No alert, no SPI, aircraft airborne
-                        1: No alert, no SPI, aircraft on ground
-                        2: Alert, no SPI, aircraft airborne
-                        3: Alert, no SPI, aircraft on ground
-                        4: Alert, SPI, aircraft airborne or on ground
-                        5: No alert, SPI, aircraft airborne or on ground
-                        6: General Emergency
-                        7: Lifeguard / medical
-                        8: Minimum fuel
-                        9: No communications
-                        10: Unlawful
-            spare 1
-            SSC "Specific service capability"
-                fixed 1
-                    table
-                        0: No
-                        1: Yes
-            ARC "Altitude reporting capability"
-               fixed 1
-                   table
-                       0: 100 ft resolution
-                       1: 25 ft resolution
-            AIC "Aircraft identification capability"
-               fixed 1
-                   table
-                       0: No
-                       1: Yes
-            B1A "BDS 1,0 bit 16"
-               fixed 1
-                   unsigned integer
-            B1B "BDS 1,0 bit 37/40"
-               fixed 4
-                   unsigned integer
-            AC "ACAS operational"
-               fixed 1
-                   table
-                       0: No
-                       1: Yes
-            MN "Multiple navigational aids operating"
-               fixed 1
-                   table
-                       0: No
-                       1: Yes
-            DC "Differential correction"
-                fixed 1
-                    table
-                        0: Yes
-                        1: No
-            spare 5
-            // TODO: subfield 8
+            -
+            -
+            -
+            subitems
+                STAT "Flight Status"
+                    fixed 4
+                        table
+                            0: No alert, no SPI, aircraft airborne
+                            1: No alert, no SPI, aircraft on ground
+                            2: Alert, no SPI, aircraft airborne
+                            3: Alert, no SPI, aircraft on ground
+                            4: Alert, SPI, aircraft airborne or on ground
+                            5: No alert, SPI, aircraft airborne or on ground
+                            6: General Emergency
+                            7: Lifeguard / medical
+                            8: Minimum fuel
+                            9: No communications
+                            10: Unlawful
+                spare 1
+                SSC "Specific service capability"
+                    fixed 1
+                        table
+                            0: No
+                            1: Yes
+                ARC "Altitude reporting capability"
+                   fixed 1
+                       table
+                           0: 100 ft resolution
+                           1: 25 ft resolution
+                AIC "Aircraft identification capability"
+                   fixed 1
+                       table
+                           0: No
+                           1: Yes
+                B1A "BDS 1,0 bit 16"
+                   fixed 1
+                       unsigned integer
+                B1B "BDS 1,0 bit 37/40"
+                   fixed 4
+                       unsigned integer
+                AC "ACAS operational"
+                   fixed 1
+                       table
+                           0: No
+                           1: Yes
+                MN "Multiple navigational aids operating"
+                   fixed 1
+                       table
+                           0: No
+                           1: Yes
+                DC "Differential correction"
+                    fixed 1
+                        table
+                            0: Yes
+                            1: No
+                spare 5
             AircraftType "Aircraft Derived Aircraft Type"
                 fixed 32
                     string ascii
-            // TODO: subfield 9
             ECAT "Emitter category"
                 fixed 8
                     table
@@ -519,85 +518,84 @@ items
                         22: fixed ground or tethered obstruction 
                         23: reserved 
                         24: reserved 
-            // TODO: subfield 11
-            VDL "VDL Mode 4"
-                fixed 1
-                    table
-                        0: VDL Mode 4 available 
-                        1: VDL Mode 4 not available 
-            MDS "Mode S"
-                fixed 1
-                    table
-                        0: Mode S available
-                        1: Mode S not available
-            UAT "UAT"
-                fixed 1
-                    table
-                        0: UAT available
-                        1: UAT not available
-            spare 5
+            -
+            subitems
+                VDL "VDL Mode 4"
+                    fixed 1
+                        table
+                            0: VDL Mode 4 available 
+                            1: VDL Mode 4 not available 
+                MDS "Mode S"
+                    fixed 1
+                        table
+                            0: Mode S available
+                            1: Mode S not available
+                UAT "UAT"
+                    fixed 1
+                        table
+                            0: UAT available
+                            1: UAT not available
+                spare 5
+            -
 
     390 "Flight Plan Related Data"
         optional
         definition
             All flight plan related information.
-        compound // TODO: length of primary part: 2
-            // TODO: subfield 1
-            SAC "System Area Code"
-                fixed 8
-                    unsigned integer
-            SIC "System Identity Code"
-                fixed 8
-                    unsigned integer
-            // TODO: subfield 2
+        compound
+            subitems
+              SAC "System Area Code"
+                  fixed 8
+                      unsigned integer
+              SIC "System Identity Code"
+                  fixed 8
+                      unsigned integer
             CSN "Callsign"
                 fixed 56
                     string ascii
-            // TODO: subfield 3
-            TYP "IFPS Flight ID Type"
-                fixed 2
-                    table
-                        0: Plan number 
-                        1: Unit 1 internal flight number
-                        2: Unit 2 internal flight number
-                        3: Unit 3 internal flight number
-            spare 3
-            NBR "IFPS Flight ID Number"
-                fixed 27
-                    unsigned integer
-            // TODO: subfield 4
-            GAT_OAT "Flight type"
-                fixed 2
-                    table
-                        0: Unknown
-                        1: General Air Traffic
-                        2: Operational Air Traffic
-                        3: Not applicable
-            FR1_FR2 "Flight rules"
-                fixed 2
-                    table
-                        0: Instrument Flight Rules
-                        1: Visual Flight rules
-                        2: Not applicable
-                        3: Controlled Visual Flight Rules
-            RVSM "RVSM"
-                fixed 2
-                    table
-                        0: Unknown Instrument Flight Rules
-                        1: Approved
-                        2: Exempt
-                        3: Not Approved
-            HPR "Flight priority"
-                fixed 1
-                    table
-                        0: Normal Priority Flight
-                        1: High Priority Flight
-            spare 1
-            // TODO: subfield 5
+            subitems
+                TYP "IFPS Flight ID Type"
+                    fixed 2
+                        table
+                            0: Plan number 
+                            1: Unit 1 internal flight number
+                            2: Unit 2 internal flight number
+                            3: Unit 3 internal flight number
+                spare 3
+                NBR "IFPS Flight ID Number"
+                    fixed 27
+                        unsigned integer
+            subitems
+                GAT_OAT "Flight type"
+                    fixed 2
+                        table
+                            0: Unknown
+                            1: General Air Traffic
+                            2: Operational Air Traffic
+                            3: Not applicable
+                FR1_FR2 "Flight rules"
+                    fixed 2
+                        table
+                            0: Instrument Flight Rules
+                            1: Visual Flight rules
+                            2: Not applicable
+                            3: Controlled Visual Flight Rules
+                RVSM "RVSM"
+                    fixed 2
+                        table
+                            0: Unknown Instrument Flight Rules
+                            1: Approved
+                            2: Exempt
+                            3: Not Approved
+                HPR "Flight priority"
+                    fixed 1
+                        table
+                            0: Normal Priority Flight
+                            1: High Priority Flight
+                spare 1
             TOA "Type of Aircraft"
                 fixed 32
                     string ascii
-            // TODO: subfield 6
             WTC "Wake Turbulence Category"
                 fixed 8
                     table
@@ -605,78 +603,70 @@ items
                         77: Medium
                         72: Heavy
                         74: Super
-            // TODO: subfield 7
             ADEP "Departure Airport"
                 fixed 32
                     string ascii
-            // TODO: subfield 8
             ADES "Destination Airport"
                 fixed 32
                     string ascii
-            // TODO: subfield 9
             RWY "DRunway Designation"
                 fixed 24
                     string ascii
-            // TODO: subfield 10
             CFL "Current Cleared Flight Level"
                 fixed 16
                     unsigned quantity 0.25 0 "FL"
-            // TODO: subfield 11
-            Centre "8-bit group Identification code"
-                fixed 8
-                    unsigned integer
-            Position "8-bit Control Position identification code"
-                fixed 8
-                    unsigned integer
-            // TODO: subfield 12
-            SUB12 "TODO: Subfield 12"
-                repetitive 5
-                    subitems
-                        TYP "Time Type"
-                            fixed 5
-                                table
-                                    0: Scheduled off-block time
-                                    1: Estimated off-block time
-                                    2: Estimated take-off time
-                                    3: Actual off-block time
-                                    4: Predicted time at runway hold
-                                    5: Actual time at runway hold
-                                    6: Actual line-up time
-                                    7: Actual take-off time
-                                    8: Estimated time of arrival
-                                    9: Predicted landing time
-                                    10: Actual landing time
-                                    11: Actual time off runway
-                                    12: Predicted time to gate
-                                    13: Actual on-block time
-                        DAY "Day"
-                            fixed 2
-                                table
-                                    0: Today
-                                    1: Yesterday
-                                    2: Tomorrow
-                        spare 4
-                        HOR "Hours, from 0 to 23"
-                            fixed 5
-                                unsigned integer
-                        spare 2
-                        MIN "Minutes, from 0 to 59"
-                            fixed 6
-                                unsigned integer
-                        AVS "Seconds available"
-                            fixed 1
-                                table
-                                    0: Seconds available
-                                    1: Seconds not available
-                        spare 1
-                        SEC "Seconds, from 0 to 59"
-                            fixed 6
-                                unsigned integer
-            // TODO: subfield 13
+            subitems
+                Centre "8-bit group Identification code"
+                    fixed 8
+                        unsigned integer
+                Position "8-bit Control Position identification code"
+                    fixed 8
+                        unsigned integer
+            repetitive 1
+                subitems
+                    TYP "Time Type"
+                        fixed 5
+                            table
+                                0: Scheduled off-block time
+                                1: Estimated off-block time
+                                2: Estimated take-off time
+                                3: Actual off-block time
+                                4: Predicted time at runway hold
+                                5: Actual time at runway hold
+                                6: Actual line-up time
+                                7: Actual take-off time
+                                8: Estimated time of arrival
+                                9: Predicted landing time
+                                10: Actual landing time
+                                11: Actual time off runway
+                                12: Predicted time to gate
+                                13: Actual on-block time
+                    DAY "Day"
+                        fixed 2
+                            table
+                                0: Today
+                                1: Yesterday
+                                2: Tomorrow
+                    spare 4
+                    HOR "Hours, from 0 to 23"
+                        fixed 5
+                            unsigned integer
+                    spare 2
+                    MIN "Minutes, from 0 to 59"
+                        fixed 6
+                            unsigned integer
+                    AVS "Seconds available"
+                        fixed 1
+                            table
+                                0: Seconds available
+                                1: Seconds not available
+                    spare 1
+                    SEC "Seconds, from 0 to 59"
+                        fixed 6
+                            unsigned integer
             STAND "Aircraft Stand"
                 fixed 48
                     string ascii
-            // TODO: subfield 14
             EMP "Stand empty"
                 fixed 2
                     table
@@ -714,45 +704,41 @@ items
         optional
         definition
             Overview of all important accuracies (standard deviations).
-        compound // TODO: length of primary part: 2
-            // TODO: subfield 1
-            APC_X "Estimated accuracy of the calculated position of X Component"
-                fixed 8
-                    unsigned quantity 0.25 0 "m"
-            APC_Y "Estimated accuracy of the calculated position of Y Component"
-                fixed 8
-                    unsigned quantity 0.25 0 "m"
-            // TODO: subfield 2
-            APW_Lat "APW Latitude Component Accuracy"
-                fixed 16
-                    signed quantity 8.38190317153 8 "deg"
-                    // TODO should be -8
-            APW_Lon "APW Longitude Component Accuracy"
-                fixed 16
-                    signed quantity 8.38190317153 8 "deg"
-                    // TODO should be -8
-            // TODO: subfield 3
+        compound
+            subitems
+              APC_X "Estimated accuracy of the calculated position of X Component"
+                  fixed 8
+                      unsigned quantity 0.25 0 "m"
+              APC_Y "Estimated accuracy of the calculated position of Y Component"
+                  fixed 8
+                      unsigned quantity 0.25 0 "m"
+            subitems
+              APW_Lat "APW Latitude Component Accuracy"
+                  fixed 16
+                      signed quantity 180 31 "deg"
+              APW_Lon "APW Longitude Component Accuracy"
+                  fixed 16
+                      signed quantity 180 31 "deg"
             ATH "Estimated Accuracy Of Track Height"
                 fixed 16
                     signed quantity 0.5 0 "m"
-            // TODO: subfield 4
-            AVC_X "Estimated accuracy of the calculated velocity of X Component"
-                fixed 8
-                    unsigned quantity 0.1 0 "m/s"
-            AVC_Y "Estimated accuracy of the calculated velocity of Y Component"
-                fixed 8
-                    unsigned quantity 0.1 0 "m/s"
-            // TODO: subfield 5
+            subitems
+                AVC_X "Estimated accuracy of the calculated velocity of X Component"
+                    fixed 8
+                        unsigned quantity 0.1 0 "m/s"
+                AVC_Y "Estimated accuracy of the calculated velocity of Y Component"
+                    fixed 8
+                        unsigned quantity 0.1 0 "m/s"
             ARC "Estimated Accuracy Of Rate Of Climb / Descent"
                 fixed 16
                     signed quantity 0.1 0 "m/s"
-            // TODO: subfield 6
-            AAC_X "Estimated Accuracy Of Acceleration of X Component"
-                fixed 8
-                    unsigned quantity 0.01 0 "m/s2"
-            AAC_Y "Estimated Accuracy Of Acceleration of Y Component"
-                fixed 8
-                    unsigned quantity 0.01 0 "m/s2"
+            subitems
+                AAC_X "Estimated Accuracy Of Acceleration of X Component"
+                    fixed 8
+                        unsigned quantity 0.01 0 "m/s2"
+                AAC_Y "Estimated Accuracy Of Acceleration of Y Component"
+                    fixed 8
+                        unsigned quantity 0.01 0 "m/s2"
 
     600 "Alert messages"
         optional

--- a/specs/cat011/v1.2.ast
+++ b/specs/cat011/v1.2.ast
@@ -494,11 +494,11 @@ items
             ECAT "Emitter category"
                 fixed 8
                     table
-                        1: light aircraft ≤ 7000 kg 
+                        1: light aircraft <= 7000 kg 
                         2: reserved 
                         3: 7000 kg &lt; medium aircraft &lt; 136000 kg 
                         4: reserved 
-                        5: 136000 kg ≤ heavy aircraft 
+                        5: 136000 kg <= heavy aircraft 
                         6: highly manoeuvrable (5g acceleration capability) and high speed (&gt;400 knots cruise) 
                         7: reserved 
                         8: reserved 

--- a/specs/cat011/v1.2.ast
+++ b/specs/cat011/v1.2.ast
@@ -1,0 +1,907 @@
+asterix 011 "Transmission of A-SMGCS Data"
+edition 1.2
+date 2008-5-1
+preamble
+    Surveillance data exchange.
+
+items
+
+    000 "Message Type"
+        mandatory           // not specified as such in pdf
+        definition
+            This Data Item allows for a more convenient handling of the messages
+            at the receiver side by further defining the type of transaction.
+        subitems
+            MsgTyp "Type of msg."
+                fixed 8
+                    table
+                         1: Target reports, flight plan data and basic alerts
+                         2: Manual attachment of flight plan to track
+                         3: Manual detachment of flight plan to track
+                         4: Insertion of flight plan data
+                         5: Suppression of flight plan data
+                         6: Modification of flight plan data
+                         7: Holdbar status
+
+    010 "Data Source Identifier"
+        mandatory           // not specified as such in pdf
+        definition
+            Identification of the radar station from which the data are received.
+        subitems
+            SAC "System Area Code"
+                fixed 8
+                    raw
+            SIC "System Identification code"
+                fixed 8
+                    raw
+        remark
+            Note:
+                The defined SACs are on the EUROCONTROL ASTERIX website
+                (www.eurocontrol.int/asterix)
+
+    015 "Service Identification"
+        mandatory           // not specified as such in pdf
+        definition
+            Identification of the service provided to one or more users. 
+        subitems
+            SI "Service Identification"
+                fixed 8
+                    raw
+        remark
+            Note:
+                The service identification is allocated by the A-SMGCS
+            
+    041 "Position in WGS-84 Coordinates"
+        mandatory           // not specified as such in pdf
+        definition
+            Position of a target in WGS-84 Coordinates.
+        subitems
+            Lat "Latitude in WGS-84 in two's complement"
+                fixed 32
+                    signed quantity 0.00000008381903171539306640625 0 "deg" >= -90 <= 90
+            Lon "Longitude in WGS-84 in two's complement"
+                fixed 32
+                    signed quantity 0.00000008381903171539306640625 0 "deg" >= -90 <= 90
+
+    042 "Calculated Position in Cartesian Co-ordinates"
+        mandatory           // not specified as such in pdf
+        definition
+            Calculated position of a target in Cartesian co-ordinates (two's complement form).
+        subitems
+            X "X-Component"
+                fixed 32
+                    signed quantity 0.00000008381903171539306640625 0 "m" >= -32768 <= 32768
+            Y "X-Component"
+                fixed 32
+                    signed quantity 0.00000008381903171539306640625 0 "m" >= -32768 <= 32768
+
+    060 "Mode-3/A Code in Octal Representation"
+        optional
+        definition
+            Track Mode-3/A code converted into octal representation.
+        subitems
+            spare 4
+            Mod3A "Mode-3/A reply in octal representation" // TODO octal format
+                fixed 12
+                    unsigned integer
+
+    090 "Measured Flight Level"
+        optional
+        definition
+            Last valid and credible flight level used to update the track, in two's complement representation.
+        subitems
+            MFL "Measured Flight Level"
+                fixed 16
+                    signed quantity 0.25 0 "FL" >= -12 <= 1500
+       remark
+            Note:
+                 The criteria to determine the credibility of the flight level are Tracker dependent.
+                 Credible means: within reasonable range of change with respect to the previous detection.
+
+    092 "Calculated Track Geometric Altitude"
+        optional
+        definition
+            Calculated Track Geometric Altitude Calculated geometric vertical distance above mean sea level, not related to barometric pressure.
+        subitems
+            CTGA "Calculated Track Geometric Altitude"
+                fixed 16
+                    signed quantity 6.25 0 "ft" >= -1500 <= 150000
+       remark
+            Note:
+                 The source of altitude is identified in bits (SRC) of item I011/170 Track Status.
+
+    093 "Calculated Track Barometric Altitude"
+        optional
+        definition
+            Calculated Barometric Altitude of the track.
+        subitems
+            QNH "QNH correction applied"
+                fixed 1
+                    table
+                        0: No QNH correction applied
+                        1: QNH correction applied
+            CTBA "Calculated Track Barometric Altitude"
+                fixed 15
+                    signed quantity 0.25 0 "ft" >= -15 <= 1500
+
+    140 "Time of Track Information"
+        mandatory
+        definition
+            Absolute time stamping expressed as UTC.
+        subitems
+            ToTI "Time of Track Information"
+                fixed 24
+                    signed quantity 0.0078125 0 "s"
+        remark
+            Note:
+                The time of day value is reset to zero each day at midnight.
+
+    161 "Track Number"
+        optional
+        definition
+            Identification of a fusion track (single track number).
+        subitems
+            spare 1
+            FTN "Fusion Track Number"
+                fixed 15
+                    unsigned integer
+
+    170 "Track Status"
+        optional
+        definition
+            Status of track.
+        extended 8 8
+            MON ""
+                fixed 1
+                    table
+                        0: Multisensor Track
+                        1: Monosensor Track
+                        
+            GBS ""
+                fixed 1
+                    table
+                        0: Transponder Ground bit not set or unknown
+                        1: Transponder Ground bit set
+            MRH ""
+                fixed 1
+                    table
+                        0: Barometric altitude (Mode C) more reliable
+                        1: Geometric altitude more reliable
+            SRC ""
+                fixed 3
+                    table
+                        0: no source
+                        1: GPS
+                        2: 3d radar
+                        3: triangulation
+                        4: height from coverage
+                        5: speed look-up table
+                        6: default height
+                        7: multilateration
+            CNF ""
+                fixed 1
+                    table
+                        0: Confirmed track
+                        1: Tentative track
+            SIM ""
+                fixed 1
+                    table
+                        0: Actual Track
+                        1: Simulated track
+            TSE ""
+                fixed 1
+                    table
+                        0: default value
+                        1: track service end (i.e. last message transmitted to the user for the track).
+            TSB ""
+                fixed 1
+                    table
+                        0: default value
+                        1: track service begin (i.e. first message transmitted to the user for the track)
+            FRIFOE ""
+                fixed 2
+                    table
+                        0: No Mode 4 interrogationt
+                        1: Friendly target
+                        2: Unknown target
+                        3: No reply
+            ME ""
+                fixed 1
+                    table
+                        0: default value
+                        1: Military Emergency present in the last report received from a sensor capable of decoding this data
+            MI ""
+                fixed 1
+                    table
+                        0: End of Data Item
+                        1: Military Identification present in the last report received from a sensor capable of decoding this data
+            AMA ""
+                fixed 1
+                    table
+                        0: track not resulting from amalgamation process
+                        1: track resulting from amalgamation process
+            SPI ""
+                fixed 1
+                    table
+                        0: default value
+                        1: SPI present in the last report received from a sensor capable of decoding this data
+            CST ""
+                fixed 1
+                    table
+                        0: default value
+                        1: Age of the last received track update is higher than system dependent threshold (coasting)
+            FPC ""
+                fixed 1
+                    table
+                        0: Not flight-plan correlated
+                        1: Flight plan correlated
+            AFF ""
+                fixed 1
+                    table
+                        0: default value
+                        1: ADS-B data inconsistent with other surveillance information
+            spare 2
+
+    202 "Calculated Track Velocity in Cartesian Coordinates"
+        optional
+        definition
+           Calculated track velocity expressed in Cartesian co-ordinates.
+        subitems
+            Vx "Vx"
+                fixed 16
+                    signed quantity 0.25 0 "m/s" >= -8192 <= 8192
+            Vy "Vy"
+                fixed 16
+                    signed quantity 0.25 0 "m/s" >= -8192 <= 8192
+
+    210 "Calculated Acceleration"
+        optional
+        definition
+            Calculated Acceleration of the target, in two's complement form.
+        subitems
+            Ax "Ax"
+                fixed 8
+                    signed quantity 0.25 0 "m/s2" >= -31 <= 31
+            Ay "Ay"
+                fixed 8
+                    signed quantity 0.25 0 "m/s2" >= -31 <= 31
+
+    215 "Calculated Rate Of Climb/Descent"
+        optional
+        definition
+            Calculated rate of Climb/Descent of an aircraft, in two's complement form.
+        subitems
+            RoCD "Rate of Climb Descent"
+                fixed 16
+                    signed quantity 6.25 0 "ft/min" >= -204800 <= 204800
+
+    245 "Target Identification"
+        optional
+        definition
+            Target (aircraft or vehicle) identification in 8 characters.
+        subitems
+            STI ""
+                fixed 2
+                    table
+                        0: Callsign or registration downlinked from transponde
+                        1: Callsign not downlinked from transponder
+                        2: Registration not downlinked from transponder
+            spare 6
+            TId "Target Identification"
+                fixed 48
+                    unsigned integer
+        remark
+            Note:
+                Characters 1-8 (coded on 6 bits each) defining target identification
+
+    270 "Target Size and Orientation"
+        optional
+        definition
+            Target size defined as length and with of the detected target, and orientation.
+        extended 8 8
+            Length "Length"
+                fixed 7
+                    unsigned quantity 1 0 "m"
+            Ori "Orientation"
+                fixed 7
+                    unsigned quantity 2.8125 0 "deg"
+            Width "Width"
+                fixed 7
+                    unsigned quantity 1 0 "m"
+        remark
+            Note:
+                The orientation gives the direction which the aircraft nose is pointing, relative to the Geographical North. 
+
+    290 "System Track Update Ages"
+        optional    
+        definition 
+            Ages of the last plot/local track, or the last valid mode-A/mode-C, used to update the system track.
+        compound
+            PSR "Age of the last primary detection used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            SSR "Age of the last secondary detection used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            MDA "Age of the last Mode A detection used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            MFL "Age of the last Mode C detection used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            MDS "Age of the last Mode S detection used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            ADS "Age of the last ADS report used to update the track"
+                fixed 16
+                    unsigned quantity 0.25 0 "s"
+            ADB "Age of the last ADS-B report used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            MD1 "Age of the last valid Mode 1 used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            MD2 "Age of the last Mode 2 used to update the track"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            LOP "Age of the last magentic loop detection"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            TRK "Actual track age since first occurrence"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+            MUL "Age of the last multilateration detection"
+                fixed 8
+                    unsigned quantity 0.25 0 "s"
+        remark
+            Note:
+                The ages are counted from Data Item I011/140, Time Of Track
+                Information, using the following formula:
+                Age = Time of track information - Time of last (valid) update
+                If the computed age is greater than the maximum value or if the
+                data has never been received, then the corresponding subfield is not sent.
+
+    300 "Vehicle Fleet Identification"
+        optional
+        definition
+            Vehicle fleet identification number.
+        subitems
+            VFI "Vehicle Fleet Identification"
+                fixed 8
+                    table
+                        0: Flyco (follow me)
+                        1: ATC equipment maintenance
+                        2: Airport maintenance
+                        3: Fire
+                        4: Bird scarer
+                        5: Snow plough
+                        6: Runway sweeper
+                        7: Emergency
+                        8: Police
+                        9: Bus
+                        10: Tug (push/tow)
+                        11: Grass cutter
+                        12: Fuel
+                        13: Baggage
+                        14: Catering
+                        15: Aircraft maintenance
+                        16: Unknown
+
+    310 "Pre-programmed Message"
+        optional
+        definition
+            Number related to a pre-programmed message that can be transmitted by a vehicle.
+        subitems
+            TRB "In trouble"
+                fixed 1
+                    table
+                        0: Default
+                        1: In Trouble
+            MSG "Message"
+                fixed 7
+                    table
+                        1: Towing aircraft
+                        2: "Follow me" operation
+                        3: Runway check
+                        4: Emergency operation (fire, medical...)
+                        5: Work in progress (maintenance, birds scarer, sweepers...)
+
+    380 "Mode-S / ADS-B Related Data"
+        optional
+        definition
+            Data specific to Mode-S ADS-B.
+        compound 
+            // TODO: length of primary part: 2
+            // TODO: subfield 1
+            MB "BDS"
+                repetitive 8
+                    subitems
+                        MB "Mode S MB Data"
+                            fixed 8
+                                raw // TODO: BDS format
+            // TODO: subfield 1
+            ADR "24 bits Aircraft address"
+                fixed 24
+                    unsigned integer
+            // TODO: subfield 4
+            COM "Communications capability of the transponder"
+                fixed 3
+                    table
+                        0: No communications capability (surveillance only)
+                        1: Comm. A and Comm. B capability
+                        2: Comm. A, Comm. B and Uplink ELM
+                        3: Comm. A, Comm. B, Uplink ELM and Downlink ELM
+                        4: Level 5 Transponder capability
+                        5: Not assigned
+                        6: Not assigned
+                        7: Not assigned
+            STAT "Flight Status"
+                fixed 4
+                    table
+                        0: No alert, no SPI, aircraft airborne
+                        1: No alert, no SPI, aircraft on ground
+                        2: Alert, no SPI, aircraft airborne
+                        3: Alert, no SPI, aircraft on ground
+                        4: Alert, SPI, aircraft airborne or on ground
+                        5: No alert, SPI, aircraft airborne or on ground
+                        6: General Emergency
+                        7: Lifeguard / medical
+                        8: Minimum fuel
+                        9: No communications
+                        10: Unlawful
+            spare 1
+            SSC "Specific service capability"
+                fixed 1
+                    table
+                        0: No
+                        1: Yes
+            ARC "Altitude reporting capability"
+               fixed 1
+                   table
+                       0: 100 ft resolution
+                       1: 25 ft resolution
+            AIC "Aircraft identification capability"
+               fixed 1
+                   table
+                       0: No
+                       1: Yes
+            B1A "BDS 1,0 bit 16"
+               fixed 1
+                   unsigned integer
+            B1B "BDS 1,0 bit 37/40"
+               fixed 4
+                   unsigned integer
+            AC "ACAS operational"
+               fixed 1
+                   table
+                       0: No
+                       1: Yes
+            MN "Multiple navigational aids operating"
+               fixed 1
+                   table
+                       0: No
+                       1: Yes
+            DC "Differential correction"
+                fixed 1
+                    table
+                        0: Yes
+                        1: No
+            spare 5
+            // TODO: subfield 8
+            AircraftType "Aircraft Derived Aircraft Type"
+                fixed 32
+                    string ascii
+            // TODO: subfield 9
+            ECAT "Emitter category"
+                fixed 8
+                    table
+                        1: light aircraft ≤ 7000 kg 
+                        2: reserved 
+                        3: 7000 kg &lt; medium aircraft &lt; 136000 kg 
+                        4: reserved 
+                        5: 136000 kg ≤ heavy aircraft 
+                        6: highly manoeuvrable (5g acceleration capability) and high speed (&gt;400 knots cruise) 
+                        7: reserved 
+                        8: reserved 
+                        9: reserved 
+                        10: rotocraft 
+                        11: glider / sailplane 
+                        12: lighter-than-air 
+                        13: unmanned aerial vehicle 
+                        14: space / transatmospheric vehicle 
+                        15: ultralight / handglider / paraglider 
+                        16: parachutist / skydiver 
+                        17: reserved 
+                        18: reserved 
+                        19: reserved 
+                        20: surface emergency vehicle 
+                        21: surface service vehicle 
+                        22: fixed ground or tethered obstruction 
+                        23: reserved 
+                        24: reserved 
+            // TODO: subfield 11
+            VDL "VDL Mode 4"
+                fixed 1
+                    table
+                        0: VDL Mode 4 available 
+                        1: VDL Mode 4 not available 
+            MDS "Mode S"
+                fixed 1
+                    table
+                        0: Mode S available
+                        1: Mode S not available
+            UAT "UAT"
+                fixed 1
+                    table
+                        0: UAT available
+                        1: UAT not available
+            spare 5
+
+    390 "Flight Plan Related Data"
+        optional
+        definition
+            All flight plan related information.
+        compound // TODO: length of primary part: 2
+            // TODO: subfield 1
+            SAC "System Area Code"
+                fixed 8
+                    unsigned integer
+            SIC "System Identity Code"
+                fixed 8
+                    unsigned integer
+            // TODO: subfield 2
+            CSN "Callsign"
+                fixed 56
+                    string ascii
+            // TODO: subfield 3
+            TYP "IFPS Flight ID Type"
+                fixed 2
+                    table
+                        0: Plan number 
+                        1: Unit 1 internal flight number
+                        2: Unit 2 internal flight number
+                        3: Unit 3 internal flight number
+            spare 3
+            NBR "IFPS Flight ID Number"
+                fixed 27
+                    unsigned integer
+            // TODO: subfield 4
+            GAT_OAT "Flight type"
+                fixed 2
+                    table
+                        0: Unknown
+                        1: General Air Traffic
+                        2: Operational Air Traffic
+                        3: Not applicable
+            FR1_FR2 "Flight rules"
+                fixed 2
+                    table
+                        0: Instrument Flight Rules
+                        1: Visual Flight rules
+                        2: Not applicable
+                        3: Controlled Visual Flight Rules
+            RVSM "RVSM"
+                fixed 2
+                    table
+                        0: Unknown Instrument Flight Rules
+                        1: Approved
+                        2: Exempt
+                        3: Not Approved
+            HPR "Flight priority"
+                fixed 1
+                    table
+                        0: Normal Priority Flight
+                        1: High Priority Flight
+            spare 1
+            // TODO: subfield 5
+            TOA "Type of Aircraft"
+                fixed 32
+                    string ascii
+            // TODO: subfield 6
+            WTC "Wake Turbulence Category"
+                fixed 8
+                    table
+                        76: Light
+                        77: Medium
+                        72: Heavy
+                        74: Super
+            // TODO: subfield 7
+            ADEP "Departure Airport"
+                fixed 32
+                    string ascii
+            // TODO: subfield 8
+            ADES "Destination Airport"
+                fixed 32
+                    string ascii
+            // TODO: subfield 9
+            RWY "DRunway Designation"
+                fixed 24
+                    string ascii
+            // TODO: subfield 10
+            CFL "Current Cleared Flight Level"
+                fixed 16
+                    unsigned quantity 0.25 0 "FL"
+            // TODO: subfield 11
+            Centre "8-bit group Identification code"
+                fixed 8
+                    unsigned integer
+            Position "8-bit Control Position identification code"
+                fixed 8
+                    unsigned integer
+            // TODO: subfield 12
+            SUB12 "TODO: Subfield 12"
+                repetitive 5
+                    subitems
+                        TYP "Time Type"
+                            fixed 5
+                                table
+                                    0: Scheduled off-block time
+                                    1: Estimated off-block time
+                                    2: Estimated take-off time
+                                    3: Actual off-block time
+                                    4: Predicted time at runway hold
+                                    5: Actual time at runway hold
+                                    6: Actual line-up time
+                                    7: Actual take-off time
+                                    8: Estimated time of arrival
+                                    9: Predicted landing time
+                                    10: Actual landing time
+                                    11: Actual time off runway
+                                    12: Predicted time to gate
+                                    13: Actual on-block time
+                        DAY "Day"
+                            fixed 2
+                                table
+                                    0: Today
+                                    1: Yesterday
+                                    2: Tomorrow
+                        spare 4
+                        HOR "Hours, from 0 to 23"
+                            fixed 5
+                                unsigned integer
+                        spare 2
+                        MIN "Minutes, from 0 to 59"
+                            fixed 6
+                                unsigned integer
+                        AVS "Seconds available"
+                            fixed 1
+                                table
+                                    0: Seconds available
+                                    1: Seconds not available
+                        spare 1
+                        SEC "Seconds, from 0 to 59"
+                            fixed 6
+                                unsigned integer
+            // TODO: subfield 13
+            STAND "Aircraft Stand"
+                fixed 48
+                    string ascii
+            // TODO: subfield 14
+            EMP "Stand empty"
+                fixed 2
+                    table
+                        0: Empty
+                        1: Occupied
+                        2: Unknown
+            AVL "Stand available"
+                fixed 2
+                    table
+                        0: Available 
+                        1: Not available 
+                        2: Unknown 
+            spare 4
+
+    430 "Phase of flight"
+        optional
+        definition
+            Current phase of the flight.
+        subitems
+            FLS "Phase of flight"
+                fixed 8
+                    table
+                        0: unknown
+                        1: on stand
+                        2: taxiing for departure
+                        3: taxiing for arrival
+                        4: runway for departure
+                        5: runway for arrival
+                        6: hold for departure
+                        7: hold for arrival
+                        8: push back
+                        9: on finals
+
+    500 "Estimated Accuracies"
+        optional
+        definition
+            Overview of all important accuracies (standard deviations).
+        compound // TODO: length of primary part: 2
+            // TODO: subfield 1
+            APC_X "Estimated accuracy of the calculated position of X Component"
+                fixed 8
+                    unsigned quantity 0.25 0 "m"
+            APC_Y "Estimated accuracy of the calculated position of Y Component"
+                fixed 8
+                    unsigned quantity 0.25 0 "m"
+            // TODO: subfield 2
+            APW_Lat "APW Latitude Component Accuracy"
+                fixed 16
+                    signed quantity 8.38190317153 8 "deg"
+                    // TODO should be -8
+            APW_Lon "APW Longitude Component Accuracy"
+                fixed 16
+                    signed quantity 8.38190317153 8 "deg"
+                    // TODO should be -8
+            // TODO: subfield 3
+            ATH "Estimated Accuracy Of Track Height"
+                fixed 16
+                    signed quantity 0.5 0 "m"
+            // TODO: subfield 4
+            AVC_X "Estimated accuracy of the calculated velocity of X Component"
+                fixed 8
+                    unsigned quantity 0.1 0 "m/s"
+            AVC_Y "Estimated accuracy of the calculated velocity of Y Component"
+                fixed 8
+                    unsigned quantity 0.1 0 "m/s"
+            // TODO: subfield 5
+            ARC "Estimated Accuracy Of Rate Of Climb / Descent"
+                fixed 16
+                    signed quantity 0.1 0 "m/s"
+            // TODO: subfield 6
+            AAC_X "Estimated Accuracy Of Acceleration of X Component"
+                fixed 8
+                    unsigned quantity 0.01 0 "m/s2"
+            AAC_Y "Estimated Accuracy Of Acceleration of Y Component"
+                fixed 8
+                    unsigned quantity 0.01 0 "m/s2"
+
+    600 "Alert messages"
+        optional
+        definition
+            Alert involving the targets indicated in I011/605.
+        subitems
+            ACK "Alert acknowleged"
+                fixed 1
+                    table
+                        0: Alert acknowledged
+                        1: Alert not acknowledged
+            SVR "Alert severity"
+                fixed 2
+                    table
+                        0: End fo alert
+                        1: Pre-alarm
+                        2: Severe alert
+            spare 5
+            AT "Alert Type"
+                fixed 8
+                    unsigned integer
+            AN "Alert Number"
+                fixed 8
+                    unsigned integer
+
+    605 "Tracks in Alert"
+        optional
+        definition
+            List of track numbers of the targets concerned by the alert described in I011/600.
+        repetitive 2
+            subitems
+                spare 4
+                FTN "Fusion Track Number"
+                    fixed 12
+                        unsigned integer
+
+    610 "Holdbar status"
+        optional
+        definition
+            LStatus of up to sixteen banks of twelve indicators.
+        repetitive 2
+            subitems
+                BKN "Bank Number"
+                    fixed 4
+                        unsigned integer
+                I1 "Indicator 1"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I2 "Indicator 2"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I3 "Indicator 3"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I4 "Indicator 4"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I5 "Indicator 5"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I6 "Indicator 6"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I7 "Indicator 7"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I8 "Indicator 8"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I9 "Indicator 9"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I10 "Indicator 10"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I11 "Indicator 11"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+                I12 "Indicator 12"
+                    fixed 1
+                        table
+                            0: Indicator on
+                            1: Indicator off
+
+    SP "Special Purpose Field"
+        optional
+        definition
+            Special Purpose Field
+        explicit
+        
+    RE "Reserved Expansion Field"
+        optional
+        definition
+            Expansion
+        explicit
+
+uap
+    010
+    000
+    015
+    140
+    041
+    042
+    202
+    -
+    210
+    060
+    245
+    380
+    161
+    170
+    290
+    -
+    430
+    090
+    093
+    092
+    215
+    270
+    390
+    -
+    300
+    310
+    500
+    600
+    605
+    610
+    RE
+    -
+    SP

--- a/specs/cat011/v1.2.ast
+++ b/specs/cat011/v1.2.ast
@@ -421,73 +421,74 @@ items
                 fixed 24
                     unsigned integer
             -
-            COM "Communications capability of the transponder"
-                fixed 3
-                    table
-                        0: No communications capability (surveillance only)
-                        1: Comm. A and Comm. B capability
-                        2: Comm. A, Comm. B and Uplink ELM
-                        3: Comm. A, Comm. B, Uplink ELM and Downlink ELM
-                        4: Level 5 Transponder capability
-                        5: Not assigned
-                        6: Not assigned
-                        7: Not assigned
+            COMACAS "Communications/ACAS Capability and Flight Status"
+                subitems
+                    COM "Communications capability of the transponder"
+                        fixed 3
+                            table
+                                0: No communications capability (surveillance only)
+                                1: Comm. A and Comm. B capability
+                                2: Comm. A, Comm. B and Uplink ELM
+                                3: Comm. A, Comm. B, Uplink ELM and Downlink ELM
+                                4: Level 5 Transponder capability
+                                5: Not assigned
+                                6: Not assigned
+                                7: Not assigned
+                    STAT "Flight Status"
+                        fixed 4
+                            table
+                                0: No alert, no SPI, aircraft airborne
+                                1: No alert, no SPI, aircraft on ground
+                                2: Alert, no SPI, aircraft airborne
+                                3: Alert, no SPI, aircraft on ground
+                                4: Alert, SPI, aircraft airborne or on ground
+                                5: No alert, SPI, aircraft airborne or on ground
+                                6: General Emergency
+                                7: Lifeguard / medical
+                                8: Minimum fuel
+                                9: No communications
+                                10: Unlawful
+                    spare 1
+                    SSC "Specific service capability"
+                        fixed 1
+                            table
+                                0: No
+                                1: Yes
+                    ARC "Altitude reporting capability"
+                       fixed 1
+                           table
+                               0: 100 ft resolution
+                               1: 25 ft resolution
+                    AIC "Aircraft identification capability"
+                       fixed 1
+                           table
+                               0: No
+                               1: Yes
+                    B1A "BDS 1,0 bit 16"
+                       fixed 1
+                           unsigned integer
+                    B1B "BDS 1,0 bit 37/40"
+                       fixed 4
+                           unsigned integer
+                    AC "ACAS operational"
+                       fixed 1
+                           table
+                               0: No
+                               1: Yes
+                    MN "Multiple navigational aids operating"
+                       fixed 1
+                           table
+                               0: No
+                               1: Yes
+                    DC "Differential correction"
+                        fixed 1
+                            table
+                                0: Yes
+                                1: No
+                    spare 5
             -
             -
             -
-            subitems
-                STAT "Flight Status"
-                    fixed 4
-                        table
-                            0: No alert, no SPI, aircraft airborne
-                            1: No alert, no SPI, aircraft on ground
-                            2: Alert, no SPI, aircraft airborne
-                            3: Alert, no SPI, aircraft on ground
-                            4: Alert, SPI, aircraft airborne or on ground
-                            5: No alert, SPI, aircraft airborne or on ground
-                            6: General Emergency
-                            7: Lifeguard / medical
-                            8: Minimum fuel
-                            9: No communications
-                            10: Unlawful
-                spare 1
-                SSC "Specific service capability"
-                    fixed 1
-                        table
-                            0: No
-                            1: Yes
-                ARC "Altitude reporting capability"
-                   fixed 1
-                       table
-                           0: 100 ft resolution
-                           1: 25 ft resolution
-                AIC "Aircraft identification capability"
-                   fixed 1
-                       table
-                           0: No
-                           1: Yes
-                B1A "BDS 1,0 bit 16"
-                   fixed 1
-                       unsigned integer
-                B1B "BDS 1,0 bit 37/40"
-                   fixed 4
-                       unsigned integer
-                AC "ACAS operational"
-                   fixed 1
-                       table
-                           0: No
-                           1: Yes
-                MN "Multiple navigational aids operating"
-                   fixed 1
-                       table
-                           0: No
-                           1: Yes
-                DC "Differential correction"
-                    fixed 1
-                        table
-                            0: Yes
-                            1: No
-                spare 5
             AircraftType "Aircraft Derived Aircraft Type"
                 fixed 32
                     string ascii
@@ -519,23 +520,24 @@ items
                         23: reserved 
                         24: reserved 
             -
-            subitems
-                VDL "VDL Mode 4"
-                    fixed 1
-                        table
-                            0: VDL Mode 4 available 
-                            1: VDL Mode 4 not available 
-                MDS "Mode S"
-                    fixed 1
-                        table
-                            0: Mode S available
-                            1: Mode S not available
-                UAT "UAT"
-                    fixed 1
-                        table
-                            0: UAT available
-                            1: UAT not available
-                spare 5
+            AVTECH "Available Technologies"
+                subitems
+                    VDL "VDL Mode 4"
+                        fixed 1
+                            table
+                                0: VDL Mode 4 available 
+                                1: VDL Mode 4 not available 
+                    MDS "Mode S"
+                        fixed 1
+                            table
+                                0: Mode S available
+                                1: Mode S not available
+                    UAT "UAT"
+                        fixed 1
+                            table
+                                0: UAT available
+                                1: UAT not available
+                    spare 5
             -
 
     390 "Flight Plan Related Data"
@@ -543,56 +545,59 @@ items
         definition
             All flight plan related information.
         compound
-            subitems
-              SAC "System Area Code"
-                  fixed 8
-                      unsigned integer
-              SIC "System Identity Code"
-                  fixed 8
-                      unsigned integer
+            FPPSId "FPPS Identification Tag"
+                subitems
+                    SAC "System Area Code"
+                        fixed 8
+                            unsigned integer
+                    SIC "System Identity Code"
+                        fixed 8
+                            unsigned integer
             CSN "Callsign"
                 fixed 56
                     string ascii
-            subitems
-                TYP "IFPS Flight ID Type"
-                    fixed 2
-                        table
-                            0: Plan number 
-                            1: Unit 1 internal flight number
-                            2: Unit 2 internal flight number
-                            3: Unit 3 internal flight number
-                spare 3
-                NBR "IFPS Flight ID Number"
-                    fixed 27
-                        unsigned integer
-            subitems
-                GAT_OAT "Flight type"
-                    fixed 2
-                        table
-                            0: Unknown
-                            1: General Air Traffic
-                            2: Operational Air Traffic
-                            3: Not applicable
-                FR1_FR2 "Flight rules"
-                    fixed 2
-                        table
-                            0: Instrument Flight Rules
-                            1: Visual Flight rules
-                            2: Not applicable
-                            3: Controlled Visual Flight Rules
-                RVSM "RVSM"
-                    fixed 2
-                        table
-                            0: Unknown Instrument Flight Rules
-                            1: Approved
-                            2: Exempt
-                            3: Not Approved
-                HPR "Flight priority"
-                    fixed 1
-                        table
-                            0: Normal Priority Flight
-                            1: High Priority Flight
-                spare 1
+            IFPS_FLIGHT_ID "IFPS_FLIGHT_ID"
+                subitems
+                    TYP "IFPS Flight ID Type"
+                        fixed 2
+                            table
+                                0: Plan number 
+                                1: Unit 1 internal flight number
+                                2: Unit 2 internal flight number
+                                3: Unit 3 internal flight number
+                    spare 3
+                    NBR "IFPS Flight ID Number"
+                        fixed 27
+                            unsigned integer
+            FLIGHTCAT "Flight Category"
+                subitems
+                    GAT_OAT "Flight type"
+                        fixed 2
+                            table
+                                0: Unknown
+                                1: General Air Traffic
+                                2: Operational Air Traffic
+                                3: Not applicable
+                    FR1_FR2 "Flight rules"
+                        fixed 2
+                            table
+                                0: Instrument Flight Rules
+                                1: Visual Flight rules
+                                2: Not applicable
+                                3: Controlled Visual Flight Rules
+                    RVSM "RVSM"
+                        fixed 2
+                            table
+                                0: Unknown Instrument Flight Rules
+                                1: Approved
+                                2: Exempt
+                                3: Not Approved
+                    HPR "Flight priority"
+                        fixed 1
+                            table
+                                0: Normal Priority Flight
+                                1: High Priority Flight
+                    spare 1
             TOA "Type of Aircraft"
                 fixed 32
                     string ascii
@@ -615,55 +620,57 @@ items
             CFL "Current Cleared Flight Level"
                 fixed 16
                     unsigned quantity 0.25 0 "FL"
-            subitems
-                Centre "8-bit group Identification code"
-                    fixed 8
-                        unsigned integer
-                Position "8-bit Control Position identification code"
-                    fixed 8
-                        unsigned integer
-            repetitive 1
+            CCP "Current Control Position"
                 subitems
-                    TYP "Time Type"
-                        fixed 5
-                            table
-                                0: Scheduled off-block time
-                                1: Estimated off-block time
-                                2: Estimated take-off time
-                                3: Actual off-block time
-                                4: Predicted time at runway hold
-                                5: Actual time at runway hold
-                                6: Actual line-up time
-                                7: Actual take-off time
-                                8: Estimated time of arrival
-                                9: Predicted landing time
-                                10: Actual landing time
-                                11: Actual time off runway
-                                12: Predicted time to gate
-                                13: Actual on-block time
-                    DAY "Day"
-                        fixed 2
-                            table
-                                0: Today
-                                1: Yesterday
-                                2: Tomorrow
-                    spare 4
-                    HOR "Hours, from 0 to 23"
-                        fixed 5
+                    Centre "8-bit group Identification code"
+                        fixed 8
                             unsigned integer
-                    spare 2
-                    MIN "Minutes, from 0 to 59"
-                        fixed 6
+                    Position "8-bit Control Position identification code"
+                        fixed 8
                             unsigned integer
-                    AVS "Seconds available"
-                        fixed 1
-                            table
-                                0: Seconds available
-                                1: Seconds not available
-                    spare 1
-                    SEC "Seconds, from 0 to 59"
-                        fixed 6
-                            unsigned integer
+            TOD "Time of Departure"
+                repetitive 1
+                    subitems
+                        TYP "Time Type"
+                            fixed 5
+                                table
+                                    0: Scheduled off-block time
+                                    1: Estimated off-block time
+                                    2: Estimated take-off time
+                                    3: Actual off-block time
+                                    4: Predicted time at runway hold
+                                    5: Actual time at runway hold
+                                    6: Actual line-up time
+                                    7: Actual take-off time
+                                    8: Estimated time of arrival
+                                    9: Predicted landing time
+                                    10: Actual landing time
+                                    11: Actual time off runway
+                                    12: Predicted time to gate
+                                    13: Actual on-block time
+                        DAY "Day"
+                            fixed 2
+                                table
+                                    0: Today
+                                    1: Yesterday
+                                    2: Tomorrow
+                        spare 4
+                        HOR "Hours, from 0 to 23"
+                            fixed 5
+                                unsigned integer
+                        spare 2
+                        MIN "Minutes, from 0 to 59"
+                            fixed 6
+                                unsigned integer
+                        AVS "Seconds available"
+                            fixed 1
+                                table
+                                    0: Seconds available
+                                    1: Seconds not available
+                        spare 1
+                        SEC "Seconds, from 0 to 59"
+                            fixed 6
+                                unsigned integer
             STAND "Aircraft Stand"
                 fixed 48
                     string ascii
@@ -705,40 +712,44 @@ items
         definition
             Overview of all important accuracies (standard deviations).
         compound
-            subitems
-              APC_X "Estimated accuracy of the calculated position of X Component"
-                  fixed 8
-                      unsigned quantity 0.25 0 "m"
-              APC_Y "Estimated accuracy of the calculated position of Y Component"
-                  fixed 8
-                      unsigned quantity 0.25 0 "m"
-            subitems
-              APW_Lat "APW Latitude Component Accuracy"
-                  fixed 16
-                      signed quantity 180 31 "deg"
-              APW_Lon "APW Longitude Component Accuracy"
-                  fixed 16
-                      signed quantity 180 31 "deg"
+            APC "Estimated Accuracy Of Track Position (Cartesian)"
+                subitems
+                    APC_X "Estimated accuracy of the calculated position of X Component"
+                        fixed 8
+                            unsigned quantity 0.25 0 "m"
+                    APC_Y "Estimated accuracy of the calculated position of Y Component"
+                        fixed 8
+                            unsigned quantity 0.25 0 "m"
+            APW "Estimated Accuracy Of Track Position (WGS84)"
+                subitems
+                    APW_Lat "APW Latitude Component Accuracy"
+                        fixed 16
+                            signed quantity 180 31 "deg"
+                    APW_Lon "APW Longitude Component Accuracy"
+                        fixed 16
+                            signed quantity 180 31 "deg"
             ATH "Estimated Accuracy Of Track Height"
-                fixed 16
-                    signed quantity 0.5 0 "m"
-            subitems
-                AVC_X "Estimated accuracy of the calculated velocity of X Component"
-                    fixed 8
-                        unsigned quantity 0.1 0 "m/s"
-                AVC_Y "Estimated accuracy of the calculated velocity of Y Component"
-                    fixed 8
-                        unsigned quantity 0.1 0 "m/s"
+              fixed 16
+                  signed quantity 0.5 0 "m"
+            AVC "Estimated Accuracy Of Track Velocity (Cartesian)"
+                subitems
+                    AVC_X "Estimated accuracy of the calculated velocity of X Component"
+                        fixed 8
+                            unsigned quantity 0.1 0 "m/s"
+                    AVC_Y "Estimated accuracy of the calculated velocity of Y Component"
+                        fixed 8
+                            unsigned quantity 0.1 0 "m/s"
             ARC "Estimated Accuracy Of Rate Of Climb / Descent"
-                fixed 16
-                    signed quantity 0.1 0 "m/s"
-            subitems
-                AAC_X "Estimated Accuracy Of Acceleration of X Component"
-                    fixed 8
-                        unsigned quantity 0.01 0 "m/s2"
-                AAC_Y "Estimated Accuracy Of Acceleration of Y Component"
-                    fixed 8
-                        unsigned quantity 0.01 0 "m/s2"
+              fixed 16
+                  signed quantity 0.1 0 "m/s"
+            AAC "Estimated Accuracy Of Acceleration (Cartesian)"
+                subitems
+                    AAC_X "Estimated Accuracy Of Acceleration of X Component"
+                        fixed 8
+                            unsigned quantity 0.01 0 "m/s2"
+                    AAC_Y "Estimated Accuracy Of Acceleration of Y Component"
+                        fixed 8
+                            unsigned quantity 0.01 0 "m/s2"
 
     600 "Alert messages"
         optional

--- a/specs/cat011/v1.3.ast
+++ b/specs/cat011/v1.3.ast
@@ -1,6 +1,6 @@
 asterix 011 "Transmission of A-SMGCS Data"
-edition 1.2
-date 2008-5-1
+edition 1.3
+date 2020-5-11
 preamble
     Surveillance data exchange.
 
@@ -133,7 +133,7 @@ items
                     signed quantity 0.0078125 0 "s"
         remark
             Note:
-                The time of day value is reset to zero each day at midnight.
+                The Time of Track Information value is reset to zero each day at midnight.
 
     161 "Track Number"
         optional

--- a/specs/cat011/v1.3.ast
+++ b/specs/cat011/v1.3.ast
@@ -494,11 +494,11 @@ items
             ECAT "Emitter category"
                 fixed 8
                     table
-                        1: light aircraft ≤ 7000 kg 
+                        1: light aircraft <= 7000 kg 
                         2: reserved 
                         3: 7000 kg &lt; medium aircraft &lt; 136000 kg 
                         4: reserved 
-                        5: 136000 kg ≤ heavy aircraft 
+                        5: 136000 kg <= heavy aircraft 
                         6: highly manoeuvrable (5g acceleration capability) and high speed (&gt;400 knots cruise) 
                         7: reserved 
                         8: reserved 


### PR DESCRIPTION
Hi,

I added CAT011 definition and it passes validation, but I see several issues with the format:
1. Compound format is missing a specification primary part length
2. Secondary parts of compound must have indication of which bit in primary part represents presence
3. Octal format is not defined
4. Seconds paramater in quantity  (exponent ?) is not allowed to be negative. Why ?
5. I need a way to specifiy BDS format field somehow.


