### PR TITLE
improve title in CAT004 CWP LAT/LON to include Latitude/Longitude words

### DIFF
--- a/specs/cat004/cat-1.13.ast
+++ b/specs/cat004/cat-1.13.ast
@@ -1180,10 +1180,10 @@ items
                             string octal
             CPW "Predicted Conflict Position Target 1 in WGS-84 Coordinates"
                 group
-                    LAT "In WGS-84 in Two’s Complement"
+                    LAT "Latitude in WGS-84 in Two’s Complement"
                         element 32
                             signed quantity 180/2^25 "°" >= -90 <= 90
-                    LON "In WGS-84 in Two’s Complement"
+                    LON "Longitude in WGS-84 in Two’s Complement"
                         element 32
                             signed quantity 180/2^25 "°" >= -180 < 180
                     ALT "Altitude of Predicted Conflict"
@@ -1370,10 +1370,10 @@ items
                             string octal
             CPW "Predicted Conflict Position Target 2 in WGS-84 Coordinates"
                 group
-                    LAT "In WGS-84 in Two’s Complement"
+                    LAT "Latitude in WGS-84 in Two’s Complement"
                         element 32
                             signed quantity 180/2^25 "°" >= -90 <= 90
-                    LON "In WGS-84 in Two’s Complement"
+                    LON "Longitude in WGS-84 in Two’s Complement"
                         element 32
                             signed quantity 180/2^25 "°" >= -180 < 180
                     ALT "Altitude of Predicted Conflict"


### PR DESCRIPTION
This change is more of a personal taste. Current AST transcription is exactly what's in the PDF, but it makes for titles that just contain unit information, i.e. `In WGS-84 in Two’s Complement`, which is inconsistent with the rest of the fields.

This PR attempts to improve on the situation by including the words "Latitude" and "Longitude" in the titles.

Reference: CAT004 v1.13, Structure of I004/170 - Subfield # 3

![image](https://github.com/user-attachments/assets/d8f08c87-1123-4afb-ae26-566364cd9dbb)
