### PR TITLE
cat021: ref-1.5 TAO fix

### DIFF
--- a/specs/cat021/ref-1.5.ast
+++ b/specs/cat021/ref-1.5.ast
@@ -437,13 +437,13 @@ compound 1
                                 29: 54 < TAO ≤ 56
                                 30: 56 < TAO ≤ 58
                                 31: TAO > 58
-                    spare 1
                 remark
                     Notes:
 
                         1. TAO is a one-to-one copy of Message Bits 68 to 72 of the ”Aircraft
                            Operational Status Message” (Register 65 16 ). The TAO is measured
                            along the longitudinal axis of the aircraft from the forward end.
+            spare 1
             -
     TNH "True North Heading"
         definition


### PR DESCRIPTION
According to EUROCONTROL-SPEC-0149-12-A, the TAO field in I021/REF/STA only spans "bits-8/3".
The single spare bit in bit 2 thus shouldn't belong to the `group` variant but rather to the upper structure, i.e. to the `extent` variant.

Validated changes with `aspecs validate`.